### PR TITLE
Enhance analysis page presentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,10 +47,10 @@
   ############################################################ -->
   <style>
     :root{
-      --primary-50:#eff6ff; --primary-100:#dbeafe; --primary-500:#3b82f6; --primary-600:#2563eb; --primary-700:#1d4ed8;
-      --success-50:#f0fdf4; --success-500:#22c55e; --success-600:#16a34a;
-      --warning-50:#fffbeb; --warning-500:#f59e0b; --warning-600:#d97706;
-      --danger-50:#fef2f2; --danger-500:#ef4444; --danger-600:#dc2626;
+      --primary-50:#eff6ff; --primary-100:#dbeafe; --primary-200:#bfdbfe; --primary-300:#93c5fd; --primary-500:#3b82f6; --primary-600:#2563eb; --primary-700:#1d4ed8;
+      --success-50:#f0fdf4; --success-200:#bbf7d0; --success-300:#86efac; --success-500:#22c55e; --success-600:#16a34a;
+      --warning-50:#fffbeb; --warning-500:#f59e0b; --warning-600:#d97706; --warning-300:#fcd34d;
+      --danger-50:#fef2f2; --danger-500:#ef4444; --danger-600:#dc2626; --danger-300:#fca5a5;
       --gray-50:#f9fafb; --gray-100:#f3f4f6; --gray-200:#e5e7eb; --gray-300:#d1d5db; --gray-400:#9ca3af;
       --gray-500:#6b7280; --gray-600:#4b5563; --gray-700:#374151; --gray-800:#1f2937; --gray-900:#111827;
       --shadow-sm:0 1px 2px 0 rgb(0 0 0 / 0.05);
@@ -1094,10 +1094,39 @@
             </div>
 
             <div class="actions">
-              <button id="saveBtn" class="btn btn-primary">Save for later</button>
-              <button id="applyBtn" class="btn btn-success">I applied!</button>
-              <button id="coverBtn" class="btn btn-outline">Cover letter & CV</button>
-              <button id="ignoreBtn" class="btn btn-danger">Not interested</button>
+              <div class="enhanced-actions">
+                <button id="saveBtn" class="action-btn action-btn-save">
+                  <div class="btn-icon">💾</div>
+                  <div class="btn-content">
+                    <div class="btn-title">Save for Later</div>
+                    <div class="btn-subtitle">Add to saved jobs</div>
+                  </div>
+                </button>
+
+                <button id="applyBtn" class="action-btn action-btn-apply">
+                  <div class="btn-icon">✅</div>
+                  <div class="btn-content">
+                    <div class="btn-title">I Applied!</div>
+                    <div class="btn-subtitle">Mark as applied</div>
+                  </div>
+                </button>
+
+                <button id="coverBtn" class="action-btn action-btn-cover">
+                  <div class="btn-icon">📝</div>
+                  <div class="btn-content">
+                    <div class="btn-title">Cover Letter & CV</div>
+                    <div class="btn-subtitle">Get AI assistance</div>
+                  </div>
+                </button>
+
+                <button id="ignoreBtn" class="action-btn action-btn-ignore">
+                  <div class="btn-icon">❌</div>
+                  <div class="btn-content">
+                    <div class="btn-title">Not Interested</div>
+                    <div class="btn-subtitle">Dismiss this job</div>
+                  </div>
+                </button>
+              </div>
             </div>
 
             <div id="ratingInputs" class="rating-inputs" aria-hidden="true">
@@ -1385,15 +1414,10 @@
     const summaryEl = document.getElementById('summary');
     const fullDescriptionEl = document.getElementById('fullDescription');
 
-    const saveBtn = document.getElementById('saveBtn');
-    const applyBtn = document.getElementById('applyBtn');
     const ratingInputs = document.getElementById('ratingInputs');
-    const confirmApplyBtn = document.getElementById('confirmApply');
     const effortInput = document.getElementById('effort');
     const chanceInput = document.getElementById('chance');
-    const ignoreBtn = document.getElementById('ignoreBtn');
 
-    const coverBtn = document.getElementById('coverBtn');
     const coverSection = document.getElementById('coverSection');
     const coverStatus = document.getElementById('coverStatus');
     const coverContent = document.getElementById('coverContent');
@@ -2696,7 +2720,9 @@
     }
 
     function renderAnalysis(a){
-      loadingState.style.display='none'; resultContent.style.display='block';
+      loadingState.style.display='none';
+      resultContent.style.display='block';
+
       const title = a.title || a.job?.title || 'Untitled role';
       const company = a.company_name || a.job?.company_name || '';
       const locs = normalizeListField(a.locations || a.job?.locations).join(' • ');
@@ -2705,41 +2731,549 @@
       const start = a.start_date || a.job?.start_date || '';
       const url = a.source_url || a.job?.source_url || '';
 
+      const urlDisplay = url ? (() => {
+        try {
+          const urlObj = new URL(url);
+          return urlObj.hostname.replace('www.', '');
+        } catch {
+          return url.length > 40 ? url.substring(0, 40) + '...' : url;
+        }
+      })() : '—';
+
       jobTitleEl.textContent = title;
       jobCompanyEl.textContent = company;
       jobDetailsEl.innerHTML = `
-        <div class="detail-item"><div class="detail-label">Locations</div><div class="detail-value">${escapeHtml(locs || '—')}</div></div>
-        <div class="detail-item"><div class="detail-label">Salary</div><div class="detail-value">${escapeHtml(salTxt || '—')}</div></div>
-        <div class="detail-item"><div class="detail-label">Dates</div><div class="detail-value">${[start?`Start: ${start}`:'',deadline?`Deadline: ${deadline}`:''].filter(Boolean).join(' · ') || '—'}</div></div>
-        <div class="detail-item"><div class="detail-label">URL</div><div class="detail-value">${url?`<a href="${url}" target="_blank" rel="noopener">${escapeHtml(url)}</a>`:'—'}</div></div>
+        <div class="enhanced-details-grid">
+          <div class="detail-card">
+            <div class="detail-icon">📍</div>
+            <div class="detail-content">
+              <div class="detail-label">Locations</div>
+              <div class="detail-value">${escapeHtml(locs || 'Not specified')}</div>
+            </div>
+          </div>
+          <div class="detail-card">
+            <div class="detail-icon">💰</div>
+            <div class="detail-content">
+              <div class="detail-label">Salary</div>
+              <div class="detail-value">${escapeHtml(salTxt || 'Not disclosed')}</div>
+            </div>
+          </div>
+          <div class="detail-card">
+            <div class="detail-icon">📅</div>
+            <div class="detail-content">
+              <div class="detail-label">Key Dates</div>
+              <div class="detail-value">
+                ${[start ? `Start: ${start}` : '', deadline ? `Deadline: ${deadline}` : ''].filter(Boolean).join(' • ') || 'Not specified'}
+              </div>
+            </div>
+          </div>
+          <div class="detail-card">
+            <div class="detail-icon">🔗</div>
+            <div class="detail-content">
+              <div class="detail-label">Source</div>
+              <div class="detail-value">
+                ${url ? `<a href="${url}" target="_blank" rel="noopener" class="source-link">${escapeHtml(urlDisplay)} ↗</a>` : 'Direct application'}
+              </div>
+            </div>
+          </div>
+        </div>
       `;
 
       const fit = Math.max(0, Math.min(100, toNum(a.ai_fit_score ?? a.AI_fit_score) ?? 0));
       const align = Math.max(0, Math.min(100, toNum(a.ai_alignment_score ?? a.AI_alignment_score) ?? 0));
-      fitScoreEl.textContent = `${fit}%`; fitFillEl.style.width=`${fit}%`;
-      alignScoreEl.textContent = `${align}%`; alignFillEl.style.width=`${align}%`;
+      fitScoreEl.textContent = `${fit}%`;
+      fitFillEl.style.width = `${fit}%`;
+      alignScoreEl.textContent = `${align}%`;
+      alignFillEl.style.width = `${align}%`;
 
       const kw = normalizeListField(a.keywords || a.job?.keywords);
-      keywordsEl.innerHTML = kw.map(k=>`<span class="keyword">${escapeHtml(k)}</span>`).join('');
+      keywordsEl.innerHTML = kw.length ?
+        kw.map(k => `<span class="enhanced-keyword">${escapeHtml(k)}</span>`).join('') :
+        '<span class="no-keywords">No keywords identified</span>';
 
       fitsEl.textContent = bullets(normalizeListField(a.fits));
       gapsEl.textContent = bullets(normalizeListField(a.gaps));
-      summaryEl.textContent = a.job_summary || a.summary || '';
+      summaryEl.textContent = a.job_summary || a.summary || 'No summary provided';
+
+      const keywordsSection = document.querySelector('#keywords').closest('.section');
+      let requirementsSection = document.querySelector('.requirements-section');
+
+      if (!requirementsSection) {
+        requirementsSection = document.createElement('div');
+        requirementsSection.className = 'requirements-section section';
+        keywordsSection.parentNode.insertBefore(requirementsSection, keywordsSection.nextSibling);
+      }
+
+      const keyReqs = normalizeListField(a.key_requirements || a.job?.key_requirements);
+      const otherReqs = normalizeListField(a.other_requirements || a.job?.other_requirements);
+
+      const formatRequirements = (items) => {
+        const text = bullets(items);
+        return text ? escapeHtml(text).replace(/\n/g,'<br/>') : '';
+      };
+
+      requirementsSection.innerHTML = `
+        <h3 class="section-title">
+          <span class="section-icon">📋</span>
+          Requirements
+        </h3>
+        <div class="requirements-grid">
+          <div class="requirements-column">
+            <h4 class="requirements-subtitle">Essential Requirements</h4>
+            <div class="requirements-content">
+              ${keyReqs.length ? formatRequirements(keyReqs) : 'No essential requirements specified'}
+            </div>
+          </div>
+          <div class="requirements-column">
+            <h4 class="requirements-subtitle">Preferred Qualifications</h4>
+            <div class="requirements-content">
+              ${otherReqs.length ? formatRequirements(otherReqs) : 'No preferred qualifications specified'}
+            </div>
+          </div>
+        </div>
+      `;
 
       fullDescriptionEl.innerHTML = sanitizeHtml(a.job_description || '').replace(/\n/g,'<br/>');
       detailsContent.classList.remove('show');
       toggleDetailsBtn.textContent = 'View more';
-      toggleDetailsBtn.onclick = ()=>{
+      toggleDetailsBtn.onclick = () => {
         const open = detailsContent.classList.contains('show');
         detailsContent.classList.toggle('show', !open);
-        toggleDetailsBtn.textContent = open ? 'View more' : 'Hide';
+        toggleDetailsBtn.textContent = open ? 'View more' : 'Hide details';
       };
 
-      saveBtn.onclick = onSave;
-      applyBtn.onclick = ()=>{ ratingInputs.classList.add('show'); ratingInputs.setAttribute('aria-hidden','false'); };
-      confirmApplyBtn.onclick = onApply;
-      ignoreBtn.onclick = ()=>{ resultCard.style.display='none'; draft=null; lastCover=null; toast('Ignored. Nothing saved.'); };
-      coverBtn.onclick = onCoverClick;
+      const actionsContainer = document.querySelector('.actions');
+      actionsContainer.innerHTML = `
+        <div class="enhanced-actions">
+          <button id="saveBtn" class="action-btn action-btn-save">
+            <div class="btn-icon">💾</div>
+            <div class="btn-content">
+              <div class="btn-title">Save for Later</div>
+              <div class="btn-subtitle">Add to saved jobs</div>
+            </div>
+          </button>
+          
+          <button id="applyBtn" class="action-btn action-btn-apply">
+            <div class="btn-icon">✅</div>
+            <div class="btn-content">
+              <div class="btn-title">I Applied!</div>
+              <div class="btn-subtitle">Mark as applied</div>
+            </div>
+          </button>
+          
+          <button id="coverBtn" class="action-btn action-btn-cover">
+            <div class="btn-icon">📝</div>
+            <div class="btn-content">
+              <div class="btn-title">Cover Letter & CV</div>
+              <div class="btn-subtitle">Get AI assistance</div>
+            </div>
+          </button>
+          
+          <button id="ignoreBtn" class="action-btn action-btn-ignore">
+            <div class="btn-icon">❌</div>
+            <div class="btn-content">
+              <div class="btn-title">Not Interested</div>
+              <div class="btn-subtitle">Dismiss this job</div>
+            </div>
+          </button>
+        </div>
+      `;
+
+      document.getElementById('saveBtn').onclick = onSave;
+      document.getElementById('applyBtn').onclick = () => {
+        ratingInputs.classList.add('show');
+        ratingInputs.setAttribute('aria-hidden','false');
+      };
+      document.getElementById('confirmApply').onclick = onApply;
+      document.getElementById('ignoreBtn').onclick = () => {
+        resultCard.style.display='none';
+        draft=null;
+        lastCover=null;
+        toast('Ignored. Nothing saved.');
+      };
+      document.getElementById('coverBtn').onclick = onCoverClick;
+    }
+
+    const enhancedAnalysisStyles = `
+<style>
+/* Enhanced Details Grid */
+.enhanced-details-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.detail-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid var(--gray-200);
+  border-radius: 16px;
+  padding: 1.25rem;
+  transition: all 0.3s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.detail-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: var(--gradient-primary);
+  transform: scaleX(0);
+  transition: transform 0.3s ease;
+}
+
+.detail-card:hover::before {
+  transform: scaleX(1);
+}
+
+.detail-card:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-lg);
+  border-color: var(--primary-200);
+}
+
+.detail-icon {
+  font-size: 1.5rem;
+  line-height: 1;
+  flex-shrink: 0;
+  margin-top: 0.125rem;
+}
+
+.detail-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.detail-card .detail-label {
+  font-size: 0.75rem;
+  color: var(--gray-500);
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.5rem;
+}
+
+.detail-card .detail-value {
+  font-size: 1rem;
+  color: var(--gray-900);
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.source-link {
+  color: var(--primary-600);
+  text-decoration: none;
+  font-weight: 700;
+  transition: color 0.2s ease;
+}
+
+.source-link:hover {
+  color: var(--primary-700);
+  text-decoration: underline;
+}
+
+/* Enhanced Keywords */
+.enhanced-keyword {
+  display: inline-flex;
+  align-items: center;
+  background: linear-gradient(135deg, var(--primary-500), var(--primary-600));
+  color: white;
+  padding: 0.5rem 1rem;
+  border-radius: 25px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin: 0.25rem;
+  transition: all 0.3s ease;
+  box-shadow: 0 2px 4px rgba(59, 130, 246, 0.2);
+}
+
+.enhanced-keyword:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
+}
+
+.no-keywords {
+  color: var(--gray-500);
+  font-style: italic;
+  background: var(--gray-100);
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  display: inline-block;
+}
+
+/* Requirements Section */
+.requirements-section {
+  margin: 2rem 0;
+}
+
+.section-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1.25rem;
+  font-weight: 800;
+  color: var(--gray-900);
+  margin-bottom: 1rem;
+}
+
+.section-icon {
+  font-size: 1.25rem;
+}
+
+.requirements-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1.5rem;
+}
+
+.requirements-column {
+  background: rgba(255, 255, 255, 0.8);
+  border: 1px solid var(--gray-200);
+  border-radius: 16px;
+  padding: 1.5rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.requirements-column::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background: var(--gradient-primary);
+}
+
+.requirements-subtitle {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--gray-800);
+  margin: 0 0 1rem 0;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--gray-200);
+}
+
+.requirements-content {
+  color: var(--gray-700);
+  line-height: 1.6;
+  font-size: 0.95rem;
+}
+
+/* Enhanced Action Buttons */
+.enhanced-actions {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.action-btn {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  border: 2px solid transparent;
+  border-radius: 16px;
+  padding: 1.25rem;
+  cursor: pointer;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  font-family: inherit;
+  position: relative;
+  overflow: hidden;
+}
+
+.action-btn::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: var(--gradient-primary);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  z-index: -1;
+}
+
+.action-btn:hover::before {
+  opacity: 0.1;
+}
+
+.action-btn:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.15);
+  border-color: var(--primary-200);
+}
+
+.action-btn:active {
+  transform: translateY(-2px);
+}
+
+.btn-icon {
+  font-size: 1.5rem;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.btn-content {
+  flex: 1;
+  text-align: left;
+}
+
+.btn-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--gray-900);
+  margin-bottom: 0.25rem;
+}
+
+.btn-subtitle {
+  font-size: 0.875rem;
+  color: var(--gray-600);
+  line-height: 1.3;
+}
+
+.action-btn-save:hover {
+  border-color: var(--primary-300);
+}
+
+.action-btn-save .btn-icon {
+  color: var(--primary-600);
+}
+
+.action-btn-apply:hover {
+  border-color: var(--success-300);
+}
+
+.action-btn-apply .btn-icon {
+  color: var(--success-600);
+}
+
+.action-btn-cover:hover {
+  border-color: var(--warning-300);
+}
+
+.action-btn-cover .btn-icon {
+  color: var(--warning-600);
+}
+
+.action-btn-ignore:hover {
+  border-color: var(--danger-300);
+}
+
+.action-btn-ignore .btn-icon {
+  color: var(--danger-600);
+}
+
+.rating-inputs.show {
+  background: linear-gradient(135deg, rgba(34, 197, 94, 0.05), rgba(255, 255, 255, 0.95));
+  border: 2px solid var(--success-200);
+  border-radius: 16px;
+  padding: 1.5rem;
+  margin-top: 1rem;
+  box-shadow: 0 4px 12px rgba(34, 197, 94, 0.1);
+}
+
+.rating-inputs .rating-input {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.rating-inputs .rating-input label {
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: var(--gray-700);
+}
+
+.rating-inputs .rating-input input {
+  padding: 0.75rem;
+  border: 2px solid var(--gray-200);
+  border-radius: 12px;
+  font-size: 1rem;
+  font-weight: 600;
+  transition: border-color 0.2s ease;
+}
+
+.rating-inputs .rating-input input:focus {
+  border-color: var(--success-500);
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.1);
+}
+
+.rating-inputs #confirmApply {
+  background: var(--gradient-success);
+  color: white;
+  border: none;
+  padding: 1rem 2rem;
+  border-radius: 12px;
+  font-weight: 700;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.rating-inputs #confirmApply:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(34, 197, 94, 0.3);
+}
+
+.scores-section .score-card {
+  background: rgba(255, 255, 255, 0.9);
+  border: 2px solid var(--gray-200);
+  transition: all 0.3s ease;
+}
+
+.scores-section .score-card:hover {
+  transform: translateY(-4px);
+  border-color: var(--primary-300);
+  box-shadow: var(--shadow-lg);
+}
+
+@media (max-width: 768px) {
+  .enhanced-details-grid {
+    grid-template-columns: 1fr;
+  }
+  
+  .requirements-grid {
+    grid-template-columns: 1fr;
+  }
+  
+  .enhanced-actions {
+    grid-template-columns: 1fr;
+  }
+  
+  .action-btn {
+    justify-content: center;
+    text-align: center;
+  }
+  
+  .btn-content {
+    text-align: center;
+  }
+}
+
+* {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.result-card {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+</style>
+`;
+
+    if (!document.getElementById('enhanced-analysis-styles')) {
+      const styleSheet = document.createElement('style');
+      styleSheet.id = 'enhanced-analysis-styles';
+      styleSheet.textContent = enhancedAnalysisStyles.replace(/<\/?style>/g, '');
+      document.head.appendChild(styleSheet);
     }
 
     // ====== Applications send


### PR DESCRIPTION
## Summary
- redesign the analysis result actions with card-style buttons and improved layout for job details
- extend renderAnalysis to add a requirements section, clean URL display, and refreshed keyword styling with proper sanitization
- inject enhanced styling and supporting color tokens to polish fonts, cards, and responsive behavior

## Testing
- Not run (UI changes only)

------
https://chatgpt.com/codex/tasks/task_e_68d691845b78832ab1d74176816de2d5