### PR TITLE
Expose deadline modal helpers earlier for inline handlers

### DIFF
--- a/index.html
+++ b/index.html
@@ -7139,6 +7139,7 @@ function renderNewAnalyticsCharts(keywordLabels, keywordData, sectorLabels, nonR
       }
     }
 
+    // Expose modal helpers globally before inline handlers execute.
     window.openEditDeadlineModal = openEditDeadlineModal;
     window.closeEditDeadlineModal = closeEditDeadlineModal;
     window.deleteDeadline = deleteDeadline;


### PR DESCRIPTION
## Summary
- document why the deadline modal helpers are assigned to the window immediately after their definitions so inline handlers can access them

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6f4c611d0832a97bcd018a05f51d5