### PR TITLE
Fix window deadline payload end timestamp

### DIFF
--- a/index.html
+++ b/index.html
@@ -6898,7 +6898,7 @@ function renderNewAnalyticsCharts(keywordLabels, keywordData, sectorLabels, nonR
         if (date && time){
           const localDateTime = dayjs.tz(`${date} ${time}`, 'YYYY-MM-DD HH:mm', 'Europe/London');
           payload.start_at = localDateTime.toISOString();
-          payload.end_at = null;
+          payload.end_at = localDateTime.toISOString();
         } else {
           throw new Error('Date and time are required for window-type deadlines');
         }


### PR DESCRIPTION
## Summary
- ensure window-type deadlines set both start_at and end_at when submitting forms to satisfy due_by generation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d70d178d48832ab9e625bcdf074757