### PR TITLE
Revamp add application form UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,331 @@
       --glass-bg: rgba(255,255,255,0.1);
       --glass-border: rgba(255,255,255,0.2);
     }
+
+    /* Enhanced Add Application Page Styles */
+    .add-hero {
+      text-align: center;
+      margin-bottom: 3rem;
+      position: relative;
+    }
+
+    .add-hero-title {
+      font-size: clamp(2rem, 4vw, 3rem);
+      font-weight: 900;
+      background: var(--gradient-primary);
+      -webkit-background-clip: text;
+      background-clip: text;
+      -webkit-text-fill-color: transparent;
+      margin-bottom: 1rem;
+      line-height: 1.1;
+    }
+
+    .add-hero-subtitle {
+      font-size: 1.2rem;
+      color: var(--gray-600);
+      font-weight: 500;
+      max-width: 600px;
+      margin: 0 auto 2rem;
+      line-height: 1.5;
+    }
+
+    .form-progress {
+      display: flex;
+      justify-content: center;
+      gap: 0.5rem;
+      margin-bottom: 2rem;
+    }
+
+    .progress-step {
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+      background: var(--gray-300);
+      transition: all 0.3s ease;
+    }
+
+    .progress-step.active {
+      background: var(--primary-500);
+      transform: scale(1.2);
+    }
+
+    .form-sections {
+      display: flex;
+      flex-direction: column;
+      gap: 2.5rem;
+    }
+
+    .section-header {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .section-icon {
+      font-size: 1.5rem;
+      padding: 0.5rem;
+      background: var(--primary-50);
+      border-radius: 12px;
+      border: 1px solid var(--primary-200);
+    }
+
+    .section-title {
+      font-size: 1.3rem;
+      font-weight: 800;
+      color: var(--gray-900);
+    }
+
+    .section-description {
+      font-size: 0.9rem;
+      color: var(--gray-600);
+      margin-top: 0.25rem;
+    }
+
+    .enhanced-form-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 1.5rem;
+    }
+
+    .enhanced-form-field {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .enhanced-form-field.enhanced-full-width {
+      grid-column: 1 / -1;
+    }
+
+    .enhanced-field-label {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 0.95rem;
+      font-weight: 700;
+      color: var(--gray-700);
+    }
+
+    .required-indicator {
+      color: var(--danger-500);
+      font-weight: 900;
+    }
+
+    .enhanced-field-help {
+      font-size: 0.8rem;
+      color: var(--gray-500);
+      line-height: 1.4;
+      margin-top: 0.25rem;
+    }
+
+    .enhanced-form-input, .enhanced-form-select, .enhanced-form-textarea {
+      padding: 0.875rem 1rem;
+      border: 2px solid var(--gray-200);
+      border-radius: 12px;
+      font-size: 1rem;
+      font-weight: 500;
+      color: var(--gray-800);
+      background: rgba(255, 255, 255, 0.9);
+      transition: all 0.3s ease;
+      font-family: inherit;
+    }
+
+    .enhanced-form-input:focus, .enhanced-form-select:focus, .enhanced-form-textarea:focus {
+      outline: none;
+      border-color: var(--primary-500);
+      box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.1);
+      background: white;
+      transform: translateY(-1px);
+    }
+
+    .enhanced-form-textarea {
+      resize: vertical;
+      min-height: 100px;
+      line-height: 1.5;
+    }
+
+    .enhanced-form-textarea.enhanced-large {
+      min-height: 140px;
+    }
+
+    .enhanced-status-select {
+      appearance: none;
+      background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
+      background-position: right 0.5rem center;
+      background-repeat: no-repeat;
+      background-size: 1.5em 1.5em;
+      padding-right: 2.5rem;
+    }
+
+    /* Multi-input field styles */
+    .enhanced-multi-input-field {
+      position: relative;
+    }
+
+    .enhanced-multi-input-container {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      padding: 0.75rem;
+      border: 2px solid var(--gray-200);
+      border-radius: 12px;
+      background: rgba(255, 255, 255, 0.9);
+      min-height: 48px;
+      transition: all 0.3s ease;
+    }
+
+    .enhanced-multi-input-container:focus-within {
+      border-color: var(--primary-500);
+      box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.1);
+      background: white;
+    }
+
+    .enhanced-input-tag {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      background: var(--primary-50);
+      color: var(--primary-700);
+      padding: 0.375rem 0.75rem;
+      border-radius: 20px;
+      font-size: 0.875rem;
+      font-weight: 600;
+      border: 1px solid var(--primary-200);
+    }
+
+    .enhanced-input-tag .enhanced-remove-tag {
+      background: none;
+      border: none;
+      color: var(--primary-600);
+      cursor: pointer;
+      font-size: 1rem;
+      font-weight: bold;
+      padding: 0;
+      margin: 0;
+      line-height: 1;
+    }
+
+    .enhanced-input-tag .enhanced-remove-tag:hover {
+      color: var(--danger-500);
+    }
+
+    .enhanced-tag-input {
+      border: none;
+      outline: none;
+      background: transparent;
+      flex: 1;
+      min-width: 150px;
+      font-size: 0.95rem;
+      padding: 0.25rem;
+    }
+
+    .enhanced-tag-input::placeholder {
+      color: var(--gray-400);
+    }
+
+    /* Salary grid */
+    .enhanced-salary-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr 1fr 1fr;
+      gap: 1rem;
+      align-items: end;
+    }
+
+    .enhanced-salary-range-display {
+      grid-column: 1 / -1;
+      background: var(--gray-50);
+      border: 1px solid var(--gray-200);
+      border-radius: 8px;
+      padding: 0.75rem;
+      text-align: center;
+      font-weight: 600;
+      color: var(--gray-700);
+      margin-top: 0.5rem;
+    }
+
+    /* Range inputs */
+    .enhanced-number-input-group {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      padding: 0.5rem;
+      background: var(--gray-50);
+      border-radius: 12px;
+      border: 1px solid var(--gray-200);
+    }
+
+    .enhanced-form-range {
+      -webkit-appearance: none;
+      width: 100%;
+      height: 8px;
+      border-radius: 5px;
+      background: var(--gray-200);
+      outline: none;
+      padding: 0;
+      margin: 0;
+      flex: 1;
+    }
+
+    .enhanced-form-range::-webkit-slider-thumb {
+      -webkit-appearance: none;
+      appearance: none;
+      width: 24px;
+      height: 24px;
+      border-radius: 50%;
+      background: var(--primary-500);
+      cursor: pointer;
+      border: 3px solid white;
+      box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+    }
+
+    .enhanced-form-range::-moz-range-thumb {
+      width: 24px;
+      height: 24px;
+      border-radius: 50%;
+      background: var(--primary-500);
+      cursor: pointer;
+      border: 3px solid white;
+      box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+    }
+
+    .enhanced-input-suffix {
+      min-width: 40px;
+      text-align: center;
+      font-weight: 700;
+      color: var(--primary-600);
+    }
+
+    /* Form actions */
+    .enhanced-form-actions {
+      display: flex;
+      gap: 1rem;
+      justify-content: center;
+      padding-top: 2rem;
+      border-top: 2px solid var(--gray-100);
+      margin-top: 2rem;
+    }
+
+    /* Responsive design */
+    @media (max-width: 768px) {
+      .enhanced-form-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .enhanced-salary-grid {
+        grid-template-columns: 1fr 1fr;
+      }
+
+      .enhanced-form-actions {
+        flex-direction: column;
+        align-items: center;
+      }
+
+      .btn {
+        width: 100%;
+        max-width: 300px;
+      }
+    }
     *{box-sizing:border-box;margin:0;padding:0}
     body{
       font-family:'Inter',system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
@@ -2062,41 +2387,256 @@
     <!-- Add application page -->
     <div id="addPage" class="page-content">
       <div class="panel">
-        <h2 style="font-size:1.4rem;font-weight:900;color:var(--gray-900);margin-bottom:1rem">Add application</h2>
-        <form id="addForm">
-          <div class="form-grid">
-            <div class="form-field"><label>Job title</label><input name="title" placeholder="e.g. Graduate GIS Consultant" required/></div>
-            <div class="form-field"><label>Company</label><input name="company_name" placeholder="e.g. Stantec" required/></div>
-            <div class="form-field"><label>Source URL</label><input type="url" name="source_url" placeholder="https://..." /></div>
-            <div class="form-field"><label>Locations (comma separated)</label><input name="locations" placeholder="Bristol, Cambridge"/></div>
-            <div class="form-field"><label>Status</label>
-              <select name="status"></select>
+        <!-- Hero Section -->
+        <div class="add-hero">
+          <h1 class="add-hero-title">Add New Application</h1>
+          <p class="add-hero-subtitle">Keep track of your job applications with detailed information and smart organization</p>
+        </div>
+
+        <!-- Progress Indicator -->
+        <div class="form-progress">
+          <div class="progress-step active"></div>
+          <div class="progress-step active"></div>
+          <div class="progress-step active"></div>
+          <div class="progress-step active"></div>
+        </div>
+
+        <form id="enhancedAddForm">
+          <div class="form-sections">
+            <!-- Basic Information Section -->
+            <div class="form-section">
+              <div class="section-header">
+                <div class="section-icon">💼</div>
+                <div>
+                  <h3 class="section-title">Basic Information</h3>
+                  <p class="section-description">Essential details about the job opportunity</p>
+                </div>
+              </div>
+              
+              <div class="enhanced-form-grid">
+                <div class="enhanced-form-field">
+                  <label class="enhanced-field-label">
+                    Job Title <span class="required-indicator">*</span>
+                  </label>
+                  <input type="text" name="title" class="enhanced-form-input" placeholder="e.g. Graduate Software Engineer" required>
+                </div>
+
+                <div class="enhanced-form-field">
+                  <label class="enhanced-field-label">
+                    Company <span class="required-indicator">*</span>
+                  </label>
+                  <input type="text" name="company_name" class="enhanced-form-input" placeholder="e.g. Google, Microsoft, Meta" required>
+                </div>
+
+                <div class="enhanced-form-field">
+                  <label class="enhanced-field-label">Source URL</label>
+                  <input type="url" name="source_url" class="enhanced-form-input" placeholder="https://careers.company.com/job/123">
+                  <div class="enhanced-field-help">Link to the original job posting</div>
+                </div>
+
+                <div class="enhanced-form-field enhanced-status-field">
+                  <label class="enhanced-field-label">Application Status</label>
+                  <select name="status" class="enhanced-form-select enhanced-status-select">
+                    <option value="saved">💾 Saved for Later</option>
+                    <option value="applied">✅ Applied</option>
+                    <option value="oa">📝 Online Assessment</option>
+                    <option value="hirevue">🎥 HireVue Interview</option>
+                    <option value="interview">👥 Interview Scheduled</option>
+                    <option value="offer">🎉 Offer Received</option>
+                    <option value="rejected">❌ Rejected</option>
+                    <option value="withdrew">🚪 Withdrew</option>
+                  </select>
+                </div>
+              </div>
             </div>
-            <div class="form-field"><label>Applied date (YYYY-MM-DD)</label><input name="applied_date" placeholder="2025-08-29"/></div>
-            <div class="form-field"><label>Effort /10</label><input type="number" min="0" max="10" step="1" name="application_effort_rating"/></div>
-            <div class="form-field"><label>Chance /10</label><input type="number" min="0" max="10" step="1" name="application_chance_rating"/></div>
 
-            <div class="form-field"><label>AI Fit %</label><input type="number" min="0" max="100" step="1" name="ai_fit_score"/></div>
-            <div class="form-field"><label>AI Alignment %</label><input type="number" min="0" max="100" step="1" name="ai_alignment_score"/></div>
-            <div class="form-field"><label>Salary min</label><input type="number" name="salary_min"/></div>
-            <div class="form-field"><label>Salary max</label><input type="number" name="salary_max"/></div>
-            <div class="form-field"><label>Salary currency</label><input name="salary_currency" placeholder="£"/></div>
-            <div class="form-field"><label>Salary period</label><input name="salary_period" placeholder="per annum"/></div>
+            <!-- Location & Timing Section -->
+            <div class="form-section">
+              <div class="section-header">
+                <div class="section-icon">📍</div>
+                <div>
+                  <h3 class="section-title">Location & Timing</h3>
+                  <p class="section-description">Where and when this opportunity is available</p>
+                </div>
+              </div>
 
-            <div class="form-field"><label>Keywords (comma separated)</label><input name="keywords" placeholder="GIS, ArcGIS, QGIS"/></div>
-            <div class="form-field"><label>Fits (semicolon separated)</label><input name="fits" placeholder="Strong GIS modules; ArcGIS projects"/></div>
-            <div class="form-field"><label>Gaps (semicolon separated)</label><input name="gaps" placeholder="Limited commercial experience; …"/></div>
+              <div class="enhanced-form-grid">
+                <div class="enhanced-form-field">
+                  <label class="enhanced-field-label">Locations</label>
+                  <div class="enhanced-multi-input-field">
+                    <div class="enhanced-multi-input-container" id="locationsContainer">
+                      <input type="text" class="enhanced-tag-input" placeholder="Add locations (press Enter or comma)" data-field="locations">
+                    </div>
+                  </div>
+                  <div class="enhanced-field-help">Add multiple locations where this job can be performed</div>
+                </div>
 
-            <div class="form-field"><label>Summary</label><textarea name="job_summary" rows="3" placeholder="Short summary…"></textarea></div>
-            <div class="form-field" style="grid-column:1/-1"><label>Description</label><textarea name="job_description" rows="5" placeholder="Full job description…"></textarea></div>
+                <div class="enhanced-form-field">
+                  <label class="enhanced-field-label">Applied Date</label>
+                  <input type="date" name="applied_date" class="enhanced-form-input">
+                  <div class="enhanced-field-help">Leave blank if you haven't applied yet</div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Compensation Section -->
+            <div class="form-section">
+              <div class="section-header">
+                <div class="section-icon">💰</div>
+                <div>
+                  <h3 class="section-title">Compensation Details</h3>
+                  <p class="section-description">Salary and benefits information</p>
+                </div>
+              </div>
+
+              <div class="enhanced-salary-grid">
+                <div class="enhanced-form-field">
+                  <label class="enhanced-field-label">Currency</label>
+                  <select name="salary_currency" class="enhanced-form-select">
+                    <option value="">Select</option>
+                    <option value="£">£ GBP</option>
+                    <option value="$">$ USD</option>
+                    <option value="€">€ EUR</option>
+                  </select>
+                </div>
+
+                <div class="enhanced-form-field">
+                  <label class="enhanced-field-label">Minimum Salary</label>
+                  <input type="number" name="salary_min" class="enhanced-form-input enhanced-number-input" min="0" step="1000">
+                </div>
+
+                <div class="enhanced-form-field">
+                  <label class="enhanced-field-label">Maximum Salary</label>
+                  <input type="number" name="salary_max" class="enhanced-form-input enhanced-number-input" min="0" step="1000">
+                </div>
+
+                <div class="enhanced-form-field">
+                  <label class="enhanced-field-label">Period</label>
+                  <select name="salary_period" class="enhanced-form-select">
+                    <option value="">Select</option>
+                    <option value="per annum">Per Annum</option>
+                    <option value="per month">Per Month</option>
+                    <option value="per hour">Per Hour</option>
+                  </select>
+                </div>
+
+                <div class="enhanced-salary-range-display" id="salaryDisplay">
+                  Salary range will appear here
+                </div>
+              </div>
+            </div>
+
+            <!-- Assessment & Ratings Section -->
+            <div class="form-section">
+              <div class="section-header">
+                <div class="section-icon">📊</div>
+                <div>
+                  <h3 class="section-title">Personal Assessment</h3>
+                  <p class="section-description">Rate your application effort and chances</p>
+                </div>
+              </div>
+
+              <div class="enhanced-form-grid">
+                <div class="enhanced-form-field">
+                  <label class="enhanced-field-label">Application Effort</label>
+                  <div class="enhanced-number-input-group">
+                    <input type="range" name="application_effort_rating" class="enhanced-form-range" min="1" max="10" value="5" id="effortRange">
+                    <div class="enhanced-input-suffix"><span id="effortValue">5</span>/10</div>
+                  </div>
+                  <div class="enhanced-field-help">How much effort did you put into this application?</div>
+                </div>
+
+                <div class="enhanced-form-field">
+                  <label class="enhanced-field-label">Success Chance</label>
+                  <div class="enhanced-number-input-group">
+                    <input type="range" name="application_chance_rating" class="enhanced-form-range" min="1" max="10" value="5" id="chanceRange">
+                    <div class="enhanced-input-suffix"><span id="chanceValue">5</span>/10</div>
+                  </div>
+                  <div class="enhanced-field-help">How likely do you think you are to get this job?</div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Skills & Analysis Section -->
+            <div class="form-section">
+              <div class="section-header">
+                <div class="section-icon">🎯</div>
+                <div>
+                  <h3 class="section-title">Skills & Match Analysis</h3>
+                  <p class="section-description">Keywords and how well you match this role</p>
+                </div>
+              </div>
+
+              <div class="enhanced-form-grid">
+                <div class="enhanced-form-field">
+                  <label class="enhanced-field-label">Keywords & Skills</label>
+                  <div class="enhanced-multi-input-field">
+                    <div class="enhanced-multi-input-container" id="keywordsContainer">
+                      <input type="text" class="enhanced-tag-input" placeholder="Add skills and keywords (press Enter or comma)" data-field="keywords">
+                    </div>
+                  </div>
+                  <div class="enhanced-field-help">Technical skills, soft skills, and relevant keywords</div>
+                </div>
+
+                <div class="enhanced-form-field">
+                  <label class="enhanced-field-label">Perfect Matches</label>
+                  <div class="enhanced-multi-input-field">
+                    <div class="enhanced-multi-input-container" id="fitsContainer">
+                      <input type="text" class="enhanced-tag-input" placeholder="Add your strengths that match this role" data-field="fits">
+                    </div>
+                  </div>
+                  <div class="enhanced-field-help">What makes you a great fit for this position?</div>
+                </div>
+
+                <div class="enhanced-form-field">
+                  <label class="enhanced-field-label">Areas to Address</label>
+                  <div class="enhanced-multi-input-field">
+                    <div class="enhanced-multi-input-container" id="gapsContainer">
+                      <input type="text" class="enhanced-tag-input" placeholder="Add areas you need to develop" data-field="gaps">
+                    </div>
+                  </div>
+                  <div class="enhanced-field-help">Skills or experience you're still building</div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Additional Details Section -->
+            <div class="form-section">
+              <div class="section-header">
+                <div class="section-icon">📝</div>
+                <div>
+                  <h3 class="section-title">Additional Details</h3>
+                  <p class="section-description">Summary and full job description</p>
+                </div>
+              </div>
+
+              <div class="enhanced-form-grid">
+                <div class="enhanced-form-field enhanced-full-width">
+                  <label class="enhanced-field-label">Job Summary</label>
+                  <textarea name="job_summary" class="enhanced-form-textarea" rows="3" placeholder="Brief overview of the role and key responsibilities..."></textarea>
+                  <div class="enhanced-field-help">A concise summary of what this job involves</div>
+                </div>
+
+                <div class="enhanced-form-field enhanced-full-width">
+                  <label class="enhanced-field-label">Full Job Description</label>
+                  <textarea name="job_description" class="enhanced-form-textarea enhanced-large" rows="6" placeholder="Full job posting content including requirements, benefits, etc..."></textarea>
+                  <div class="enhanced-field-help">Complete job posting for future reference</div>
+                </div>
+              </div>
+            </div>
           </div>
 
-          <div class="hr"></div>
-          <div style="display:flex;gap:.75rem;flex-wrap:wrap">
-            <button class="btn btn-primary" type="submit">Save</button>
-            <button class="btn btn-outline" type="button" id="addMock">Quick add (local only)</button>
+          <!-- Action Buttons -->
+          <div class="enhanced-form-actions">
+            <button type="submit" class="btn btn-primary">
+              <span class="btn-icon">💾</span>
+              <span>Save Application</span>
+            </button>
+            <button type="button" class="btn btn-secondary" id="clearEnhancedForm">
+              <span class="btn-icon">🔄</span>
+              <span>Clear Form</span>
+            </button>
           </div>
-          <p class="help" style="margin-top:.5rem">Arrays are parsed from your comma/semicolon entries. The form saves directly to Supabase using the current environment.</p>
         </form>
       </div>
     </div>
@@ -2814,12 +3354,6 @@
     };
 
     // Add application
-    const addForm = document.getElementById('addForm');
-    const addMockBtn = document.getElementById('addMock');
-
-    // Populate Add Application status
-    const addStatusSelect = addForm.querySelector('select[name="status"]');
-    renderStatusSelect(addStatusSelect, 'saved');
 
     // Modal
     const modal = document.getElementById('applicationModal');
@@ -6705,61 +7239,248 @@ function renderNewAnalyticsCharts(keywordLabels, keywordData, sectorLabels, nonR
        BEGIN: ADD FORM (JS)
     ############################################################ */
     // ====== Add application page
-    addForm.addEventListener('submit', async (e)=>{
-      e.preventDefault();
-      const fd = new FormData(addForm);
-      // Build payload for Supabase
-      const statusSlug = normaliseStatus(fd.get('status') || 'saved');
-      const status = apiOutgoingStatus(statusSlug);
-      const payload = cleanRowForDB({
-        source_url: fd.get('source_url') || '',
-        canonical_job_url: canonicalize(fd.get('source_url') || ''),
-        title: fd.get('title') || '',
-        company_name: fd.get('company_name') || '',
-        seniority:'', role_type:'', sector:'', contact_email:'',
-        date_posted:'', date_deadline:'', start_date:'',
-        salary_min: fd.get('salary_min'),
-        salary_max: fd.get('salary_max'),
-        salary_currency: fd.get('salary_currency') || null,
-        salary_period: fd.get('salary_period') || null,
-        salary_raw: '',
-        locations: toArraySmart(fd.get('locations')),
-        ai_fit_score: fd.get('ai_fit_score'),
-        ai_alignment_score: fd.get('ai_alignment_score'),
-        ai_cv_filename:'', ai_cv_reason:'',
-        key_requirements: [],
-        other_requirements: [],
-        fits: toArraySmart(fd.get('fits')),
-        gaps: toArraySmart(fd.get('gaps')),
-        job_summary: fd.get('job_summary')||'',
-        keywords: toArraySmart(fd.get('keywords')),
-        job_description: fd.get('job_description')||'',
-        status,
-        applied_date: statusSlug === 'applied' ? (fd.get('applied_date')||londonTodayISO()) : null,
-        application_effort_rating: fd.get('application_effort_rating'),
-        application_chance_rating: fd.get('application_chance_rating'),
-        status_update_date: londonTodayISO(),
-        cover_letter_url:''
-      });
-      try{
-        await sbUpsertOnUnique(payload);
-        toast('Saved ✅');
-        addForm.reset();
-        await refreshData(true);
-      }catch(e){ console.error(e); toast('Failed to save'); }
-    });
+    // Enhanced Add application form functionality
+    class EnhancedMultiInputField {
+      constructor(container, fieldName) {
+        this.container = container;
+        this.fieldName = fieldName;
+        this.tags = [];
+        this.input = container.querySelector('.enhanced-tag-input');
+        this.setupEventListeners();
+      }
 
-    addMockBtn.onclick = ()=>{
-      const id = String(Date.now());
-      applicationsList.push({
-        id, title:'Example role', company:'Example Co', status:'saved', appliedDate:null, location:'Remote',
-        salary:'£30,000 - £35,000', fitScore:80, alignmentScore:87, source:'Manual',
-        description:'Example description…', requirements:['Req A','Req B'], fits:['Fit A'], gaps:['Gap A'],
-        effortRating:null, chanceRating:null, createdDate:londonTodayISO()
-      });
-      toast('Added locally');
-      renderSaved(); renderAnalytics();
+      setupEventListeners() {
+        this.input.addEventListener('keydown', (e) => {
+          if (e.key === 'Enter' || e.key === ',') {
+            e.preventDefault();
+            this.addTag();
+          } else if (e.key === 'Backspace' && this.input.value === '' && this.tags.length > 0) {
+            this.removeTag(this.tags.length - 1);
+          }
+        });
+
+        this.input.addEventListener('blur', () => {
+          if (this.input.value.trim()) {
+            this.addTag();
+          }
+        });
+      }
+
+      addTag() {
+        const value = this.input.value.trim();
+        if (value && !this.tags.includes(value)) {
+          this.tags.push(value);
+          this.render();
+          this.input.value = '';
+        }
+      }
+
+      removeTag(index) {
+        this.tags.splice(index, 1);
+        this.render();
+      }
+
+      render() {
+        const existingTags = this.container.querySelectorAll('.enhanced-input-tag');
+        existingTags.forEach(tag => tag.remove());
+
+        this.tags.forEach((tag, index) => {
+          const tagElement = document.createElement('div');
+          tagElement.className = 'enhanced-input-tag';
+          tagElement.innerHTML = `
+            <span>${escapeHtml(tag)}</span>
+            <button type="button" class="enhanced-remove-tag" data-index="${index}">×</button>
+          `;
+          const removeBtn = tagElement.querySelector('.enhanced-remove-tag');
+          removeBtn.addEventListener('click', () => this.removeTag(index));
+          this.container.insertBefore(tagElement, this.input);
+        });
+      }
+
+      getValue() {
+        return this.tags;
+      }
+
+      setValue(values) {
+        this.tags = Array.isArray(values) ? values : [];
+        this.render();
+      }
+    }
+
+    // Initialize enhanced multi-input fields
+    const enhancedMultiFields = {};
+
+    // Initialize enhanced form when Add page is active
+    function initEnhancedAddForm() {
+      if (document.getElementById('enhancedAddForm') && !initEnhancedAddForm._initialized) {
+        // Initialize multi-input fields
+        enhancedMultiFields.locations = new EnhancedMultiInputField(
+          document.getElementById('locationsContainer'), 'locations'
+        );
+        enhancedMultiFields.keywords = new EnhancedMultiInputField(
+          document.getElementById('keywordsContainer'), 'keywords'
+        );
+        enhancedMultiFields.fits = new EnhancedMultiInputField(
+          document.getElementById('fitsContainer'), 'fits'
+        );
+        enhancedMultiFields.gaps = new EnhancedMultiInputField(
+          document.getElementById('gapsContainer'), 'gaps'
+        );
+
+        // Range input handlers
+        const effortRange = document.getElementById('effortRange');
+        const effortValue = document.getElementById('effortValue');
+        const chanceRange = document.getElementById('chanceRange');
+        const chanceValue = document.getElementById('chanceValue');
+
+        if (effortRange && effortValue) {
+          effortRange.addEventListener('input', () => {
+            effortValue.textContent = effortRange.value;
+          });
+        }
+
+        if (chanceRange && chanceValue) {
+          chanceRange.addEventListener('input', () => {
+            chanceValue.textContent = chanceRange.value;
+          });
+        }
+
+        // Salary display update
+        function updateSalaryDisplay() {
+          const currency = document.querySelector('[name="salary_currency"]').value;
+          const min = document.querySelector('[name="salary_min"]').value;
+          const max = document.querySelector('[name="salary_max"]').value;
+          const period = document.querySelector('[name="salary_period"]').value;
+
+          const display = document.getElementById('salaryDisplay');
+
+          if (min || max) {
+            let range = '';
+            if (min && max) {
+              range = `${currency}${parseInt(min).toLocaleString()} - ${currency}${parseInt(max).toLocaleString()}`;
+            } else if (min) {
+              range = `From ${currency}${parseInt(min).toLocaleString()}`;
+            } else {
+              range = `Up to ${currency}${parseInt(max).toLocaleString()}`;
+            }
+
+            display.textContent = `${range} ${period || ''}`.trim();
+          } else {
+            display.textContent = 'Salary range will appear here';
+          }
+        }
+
+        // Add event listeners to salary fields
+        ['salary_currency', 'salary_min', 'salary_max', 'salary_period'].forEach(fieldName => {
+          const field = document.querySelector(`[name="${fieldName}"]`);
+          if (field) {
+            field.addEventListener('input', updateSalaryDisplay);
+          }
+        });
+
+        // Enhanced form submission
+        const enhancedForm = document.getElementById('enhancedAddForm');
+        enhancedForm.addEventListener('submit', async (e) => {
+          e.preventDefault();
+
+          try {
+            const formData = new FormData(e.target);
+
+            // Add multi-input field data using the same format as original form
+            Object.entries(enhancedMultiFields).forEach(([fieldName, field]) => {
+              const values = field.getValue();
+              if (values.length > 0) {
+                if (fieldName === 'locations' || fieldName === 'keywords') {
+                  formData.set(fieldName, values.join(','));
+                } else {
+                  formData.set(fieldName, values.join(';'));
+                }
+              }
+            });
+
+            // Build payload for Supabase using existing logic
+            const statusSlug = normaliseStatus(formData.get('status') || 'saved');
+            const status = apiOutgoingStatus(statusSlug);
+
+            const payload = cleanRowForDB({
+              source_url: formData.get('source_url') || '',
+              canonical_job_url: canonicalize(formData.get('source_url') || ''),
+              title: formData.get('title') || '',
+              company_name: formData.get('company_name') || '',
+              seniority: '', role_type: '', sector: '', contact_email: '',
+              date_posted: '', date_deadline: '', start_date: '',
+              salary_min: formData.get('salary_min'),
+              salary_max: formData.get('salary_max'),
+              salary_currency: formData.get('salary_currency') || null,
+              salary_period: formData.get('salary_period') || null,
+              salary_raw: '',
+              locations: toArraySmart(formData.get('locations')),
+              ai_fit_score: null,
+              ai_alignment_score: null,
+              ai_cv_filename: '', ai_cv_reason: '',
+              key_requirements: [],
+              other_requirements: [],
+              fits: toArraySmart(formData.get('fits')),
+              gaps: toArraySmart(formData.get('gaps')),
+              job_summary: formData.get('job_summary') || '',
+              keywords: toArraySmart(formData.get('keywords')),
+              job_description: formData.get('job_description') || '',
+              status,
+              applied_date: statusSlug === 'applied' ? (formData.get('applied_date') || londonTodayISO()) : null,
+              application_effort_rating: formData.get('application_effort_rating'),
+              application_chance_rating: formData.get('application_chance_rating'),
+              status_update_date: londonTodayISO(),
+              cover_letter_url: ''
+            });
+
+            await sbUpsertOnUnique(payload);
+            toast('Application saved successfully!');
+
+            // Clear form after successful submission
+            enhancedForm.reset();
+            Object.values(enhancedMultiFields).forEach(field => field.setValue([]));
+            if (effortValue) effortValue.textContent = '5';
+            if (chanceValue) chanceValue.textContent = '5';
+            updateSalaryDisplay();
+
+            await refreshData(true);
+          } catch(e) { 
+            console.error(e); 
+            toast('Failed to save application'); 
+          }
+        });
+
+        // Clear form functionality
+        const clearButton = document.getElementById('clearEnhancedForm');
+        if (clearButton) {
+          clearButton.addEventListener('click', () => {
+            if (confirm('Are you sure you want to clear all form data?')) {
+              enhancedForm.reset();
+              Object.values(enhancedMultiFields).forEach(field => field.setValue([]));
+              if (effortValue) effortValue.textContent = '5';
+              if (chanceValue) chanceValue.textContent = '5';
+              updateSalaryDisplay();
+              toast('Form cleared');
+            }
+          });
+        }
+
+        initEnhancedAddForm._initialized = true;
+      }
+    }
+
+    // Update the existing tab switching logic to initialize enhanced form
+    const originalSwitchTab = switchTab;
+    switchTab = function(name) {
+      originalSwitchTab(name);
+      if (name === 'add') {
+        initEnhancedAddForm();
+      }
     };
+
+    if (document.getElementById('addPage')?.classList.contains('active')) {
+      initEnhancedAddForm();
+    }
 
     /* ######################## END: ADD FORM (JS) ############### */
 


### PR DESCRIPTION
## Summary
- redesign the Add Application page with a hero, progress indicator, organized sections, and enhanced inputs
- add dedicated styles supporting the new add form layout, tag inputs, sliders, and responsive behavior
- replace the add-form JavaScript with enhanced tag handling, salary display updates, and tab initialization hooks

## Testing
- Manual verification: opened http://127.0.0.1:8000/index.html and navigated to the Add tab

------
https://chatgpt.com/codex/tasks/task_e_68d78b001494832a8ad42b8da3eb9020