### PR TITLE
Remove cover letter URL references from application payloads

### DIFF
--- a/index.html
+++ b/index.html
@@ -5376,7 +5376,6 @@
         application_effort_rating: toNum(opts.effort ?? a.application_effort_rating),
         application_chance_rating: toNum(opts.chance ?? a.application_chance_rating),
         status_update_date: londonTodayISO(),
-        cover_letter_url: a.cover_letter_url ?? ''
       };
     }
 
@@ -7430,7 +7429,6 @@ function renderNewAnalyticsCharts(keywordLabels, keywordData, sectorLabels, nonR
               application_effort_rating: formData.get('application_effort_rating'),
               application_chance_rating: formData.get('application_chance_rating'),
               status_update_date: londonTodayISO(),
-              cover_letter_url: ''
             });
 
             await sbUpsertOnUnique(payload);


### PR DESCRIPTION
## Summary
- stop including the removed `cover_letter_url` field when serialising application updates
- remove the empty `cover_letter_url` property from the enhanced add application form payload

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d79e5356d8832ab49f32a1194772cd